### PR TITLE
Update Flax Migrate checkpointing to Orbax guide

### DIFF
--- a/docs/notebooks/orbax_upgrade_guide.ipynb
+++ b/docs/notebooks/orbax_upgrade_guide.ipynb
@@ -5,11 +5,19 @@
    "id": "887a5094",
    "metadata": {},
    "source": [
-    "# Migrate Flax Checkpointing to Orbax\n",
+    "# Migrate checkpointing to Orbax\n",
     "\n",
-    "This guide shows you how to convert a `flax.training.checkpoints.save_checkpoint` or `restore_checkpoint` call to the equivalent in `Orbax` (go/orbax).\n",
+    "This guide shows how to convert Flax's checkpoint saving and restoring calls — [`flax.training.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint) and [`restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint) — to the equivalent [Orbax](https://github.com/google/orbax) methods. Orbax provides a flexible and customizable API for managing checkpoints for various objects. Note that as Flax's checkpointing is being migrated to Orbax from `flax.training.checkpoints`, all existing features in the Flax API will continue to be supported, but the API will change.\n",
     "\n",
-    "See also Orbax's quick start [colab introduction](http://colab.research.google.com/github/google/orbax/blob/main/orbax//checkpoint/orbax_checkpoint.ipynb) and [official documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md)."
+    "You will learn how to migrate to Orbax through the following scenarios:\n",
+    "\n",
+    "* The most common use case: Saving/loading and managing checkpoints\n",
+    "* A \"lightweight\" use case: \"Pure\" saving/loading without the top-level variable\n",
+    "* Restoring checkpoints without a target pytree\n",
+    "* Async checkpointing\n",
+    "* Saving/loading a single JAX or NumPy Array\n",
+    "\n",
+    "To learn more about Orbax, check out the [quick start introductory Colab notebook](http://colab.research.google.com/github/google/orbax/blob/main/orbax//checkpoint/orbax_checkpoint.ipynb) and [the official Orbax documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md)."
    ]
   },
   {
@@ -17,7 +25,9 @@
    "id": "e93b2509",
    "metadata": {},
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "\n",
+    "Install/upgrade [JAX](https://github.com/google/jax#installation), Flax and [Orbax](https://github.com/google/orbax). In addition, install [`nest_asyncio`](https://github.com/erdewit/nest_asyncio)."
    ]
   },
   {
@@ -33,7 +43,7 @@
    "source": [
     "!pip3 install -qq -U jaxlib jax flax orbax\n",
     "\n",
-    "# This is required for Orbax only for notebook scenarios.\n",
+    "# This is only required for Orbax in Colab/notebook scenarios.\n",
     "!pip3 install -qq nest_asyncio"
    ]
   },
@@ -54,7 +64,7 @@
     "import jax.numpy as jnp\n",
     "import numpy as np\n",
     "from orbax import checkpoint as orbax_checkpoint\n",
-    "# Orbax needs to enable asyncio in colab environment.\n",
+    "# Orbax needs to have asyncio enabled in the Colab environment.\n",
     "import nest_asyncio\n",
     "nest_asyncio.apply()"
    ]
@@ -66,13 +76,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Some dummy variables to showcase\n",
+    "# Create some dummy variables for this example.\n",
     "MAX_STEPS = 5\n",
     "CKPT_PYTREE = [12, {'foo': 'str', 'bar': np.array((2, 3))}, [1, 4, 10]]\n",
     "TARGET_PYTREE = [0, {'foo': '', 'bar': np.array((0))}, [0, 0, 0]]\n",
     "\n",
     "\n",
-    "# Remove any existing checkpoints from the last notebook run.\n",
+    "# For removing any existing checkpoints from the last notebook run:\n",
     "import shutil\n",
     "if os.path.exists('./tmp'):\n",
     "    shutil.rmtree('./tmp')"
@@ -83,7 +93,23 @@
    "id": "c6099aa3",
    "metadata": {},
    "source": [
-    "## Most Common Case: Save/Load + Management"
+    "## Most common use case: Saving/loading and managing checkpoints\n",
+    "\n",
+    "This section covers the following scenario:\n",
+    "\n",
+    "*  Your original Flax `save_checkpoint()` or `save_checkpoint_multiprocess()` call contains the following arguments: `prefix`, `keep`, `keep_every_n_steps`; or\n",
+    "*  You want to use some automatic management logic for your checkpoints (for example, for deleting old data, deleting data based on metrics/loss, and so on).\n",
+    "\n",
+    "In this case, you need to use `orbax.CheckpointManager`. This allows you to not only save and load your model, but also manage your checkpoints and delete outdated checkpoints *automatically*.\n",
+    "\n",
+    "To upgrade your code:\n",
+    "\n",
+    "1. Create and keep an `orbax.CheckpointManager` instance at the top level, customized with `orbax.CheckpointManagerOptions`.\n",
+    "2. At runtime, call `orbax.CheckpointManager.save()` to save your data.\n",
+    "3. Then, call `orbax.CheckpointManager.restore()` to restore your data.\n",
+    "4. And, if your checkpoint includes some multi-host/multi-process array, pass the correct `mesh` into `flax.training.orbax_utils.restore_args_from_target()` to generate the correct `restore_args` before restoring.\n",
+    "\n",
+    "Below are code examples for before and after the migration to Orbax:"
    ]
   },
   {
@@ -106,11 +132,11 @@
    "source": [
     "CKPT_DIR = './tmp/'\n",
     "\n",
-    "# Before\n",
+    "# Before: Using the Flax API\n",
     "\n",
     "# Inside a training loop\n",
     "for step in range(MAX_STEPS):\n",
-    "   # ... do your training ...\n",
+    "   # do your training\n",
     "   checkpoints.save_checkpoint(CKPT_DIR, CKPT_PYTREE, step=step,\n",
     "                               prefix='test_', keep=3, keep_every_n_steps=2)\n",
     "\n",
@@ -138,9 +164,9 @@
    "source": [
     "CKPT_DIR = './tmp/'\n",
     "\n",
-    "# After\n",
+    "# After: Using the Orbax API\n",
     "\n",
-    "# At top level\n",
+    "# At the top level\n",
     "mgr_options = orbax_checkpoint.CheckpointManagerOptions(\n",
     "    max_to_keep=3, keep_period=2, step_prefix='test_')\n",
     "ckpt_mgr = orbax.checkpoint.CheckpointManager(\n",
@@ -149,7 +175,7 @@
     "\n",
     "# Inside a training loop\n",
     "for step in range(MAX_STEPS):\n",
-    "   # ... do your training ...\n",
+    "   # do your training\n",
     "   save_args = orbax_utils.save_args_from_target(CKPT_PYTREE)\n",
     "   ckpt_mgr.save(step, CKPT_PYTREE, save_kwargs={'save_args': save_args})\n",
     "\n",
@@ -163,7 +189,13 @@
    "id": "25fec81a",
    "metadata": {},
    "source": [
-    "## Lightweight Case: Pure Save/Load without Top-level Variable"
+    "## A \"lightweight\" case: \"Pure\" saving/loading without the top-level variable\n",
+    "\n",
+    "If you prefer to not maintain a top-level checkpoint manager, you can still save and restore any individual checkpoint with an `orbax.checkpoint.Checkpointer`. Note that this means you cannot use all the Orbax management features.\n",
+    "\n",
+    "To migrate to Orbax code, instead of using the `overwrite` argument in `flax.save_checkpoint()` use the `force` argument in `orbax.checkpoint.Checkpointer.save()`.\n",
+    "\n",
+    "For example:"
    ]
   },
   {
@@ -186,7 +218,7 @@
    "source": [
     "PURE_CKPT_DIR = './tmp/pure'\n",
     "\n",
-    "# Before\n",
+    "# Before: Using the Flax API\n",
     "checkpoints.save_checkpoint(PURE_CKPT_DIR, CKPT_PYTREE, step=0, overwrite=True)\n",
     "checkpoints.restore_checkpoint(PURE_CKPT_DIR, target=TARGET_PYTREE)"
    ]
@@ -211,8 +243,8 @@
    "source": [
     "PURE_CKPT_DIR_ORBAX = './tmp/pure/orbax'\n",
     "\n",
-    "# After\n",
-    "ckptr = orbax_checkpoint.Checkpointer(orbax_checkpoint.PyTreeCheckpointHandler())  # stateless object, can be created on-fly\n",
+    "# After: Using the Orbax API\n",
+    "ckptr = orbax_checkpoint.Checkpointer(orbax_checkpoint.PyTreeCheckpointHandler())  # A stateless object, can be created on the fly.\n",
     "ckptr.save(PURE_CKPT_DIR_ORBAX, CKPT_PYTREE,\n",
     "           save_args=orbax_utils.save_args_from_target(CKPT_PYTREE), force=True)\n",
     "ckptr.restore(PURE_CKPT_DIR_ORBAX, item=TARGET_PYTREE,\n",
@@ -224,7 +256,11 @@
    "id": "6ea249fb",
    "metadata": {},
    "source": [
-    "## Restore without a target pytree"
+    "## Restoring checkpoints without a target pytree\n",
+    "\n",
+    "If you need to restore your checkpoints without a target pytree, pass `item=None` to `orbax.checkpoint.Checkpointer` or pass `items=None` to `orbax.CheckpointManager`'s `.restore()` method, which should trigger the restoration.\n",
+    "\n",
+    "For example:"
    ]
   },
   {
@@ -249,7 +285,7 @@
    "source": [
     "NOTARGET_CKPT_DIR = './tmp/no_target'\n",
     "\n",
-    "# Before\n",
+    "# Before: Using the Flax API\n",
     "checkpoints.save_checkpoint(NOTARGET_CKPT_DIR, CKPT_PYTREE, step=0)\n",
     "checkpoints.restore_checkpoint(NOTARGET_CKPT_DIR, target=None)"
    ]
@@ -276,7 +312,7 @@
    "source": [
     "NOTARGET_CKPT_DIR = './tmp/no_target/orbax'\n",
     "\n",
-    "# After\n",
+    "# After: Using the Orbax API\n",
     "ckptr = orbax_checkpoint.Checkpointer(orbax_checkpoint.PyTreeCheckpointHandler())\n",
     "ckptr.save(NOTARGET_CKPT_DIR, CKPT_PYTREE,\n",
     "           save_args=orbax_utils.save_args_from_target(CKPT_PYTREE))\n",
@@ -288,7 +324,19 @@
    "id": "475a6021",
    "metadata": {},
    "source": [
-    "## Save/Load a single JAX or Numpy Array"
+    "## Async checkpointing\n",
+    "\n",
+    "To make your checkpoint-saving asynchronous, substitute `orbax.checkpoint.Checkpointer` with `orbax.checkpoint.AsyncCheckpointer`.\n",
+    "\n",
+    "Then, you can call `orbax.checkpoint.AsyncCheckpointer.wait_until_finished()` or Orbax's `CheckpointerManager.wait_until_finished()` to wait for the save the complete.\n",
+    "\n",
+    "For more details, read the [checkpoint guide](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#asynchronized-checkpointing).\n",
+    "\n",
+    "## Saving/loading a single JAX or NumPy Array\n",
+    "\n",
+    "The `orbax.checkpoint.PyTreeCheckpointHandler` class, as the name suggests, can only be used for pytrees. Therefore, if you need to save/restore a single pytree leaf (for example, an array), use `orbax.checkpoint.ArrayCheckpointHandler` instead.\n",
+    "\n",
+    "For example:"
    ]
   },
   {
@@ -311,7 +359,7 @@
    "source": [
     "ARR_CKPT_DIR = './tmp/singleton'\n",
     "\n",
-    "# Before\n",
+    "# Before: Using the Flax API\n",
     "checkpoints.save_checkpoint(ARR_CKPT_DIR, jnp.arange(10), step=0)\n",
     "checkpoints.restore_checkpoint(ARR_CKPT_DIR, target=None)"
    ]
@@ -336,7 +384,7 @@
    "source": [
     "ARR_CKPT_DIR = './tmp/singleton/orbax'\n",
     "\n",
-    "# After\n",
+    "# After: Using the Orbax API\n",
     "ckptr = orbax.checkpoint.Checkpointer(orbax.checkpoint.ArrayCheckpointHandler())  # stateless object, can be created on-fly\n",
     "ckptr.save(ARR_CKPT_DIR, jnp.arange(10))\n",
     "ckptr.restore(ARR_CKPT_DIR, item=None)"

--- a/docs/notebooks/orbax_upgrade_guide.md
+++ b/docs/notebooks/orbax_upgrade_guide.md
@@ -13,19 +13,29 @@ jupyter:
     name: python3
 ---
 
-# Migrate Flax Checkpointing to Orbax
+# Migrate checkpointing to Orbax
 
-This guide shows you how to convert a `flax.training.checkpoints.save_checkpoint` or `restore_checkpoint` call to the equivalent in `Orbax` (go/orbax).
+This guide shows how to convert Flax's checkpoint saving and restoring calls — [`flax.training.checkpoints.save_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.save_checkpoint) and [`restore_checkpoint`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.checkpoints.restore_checkpoint) — to the equivalent [Orbax](https://github.com/google/orbax) methods. Orbax provides a flexible and customizable API for managing checkpoints for various objects. Note that as Flax's checkpointing is being migrated to Orbax from `flax.training.checkpoints`, all existing features in the Flax API will continue to be supported, but the API will change.
 
-See also Orbax's quick start [colab introduction](http://colab.research.google.com/github/google/orbax/blob/main/orbax//checkpoint/orbax_checkpoint.ipynb) and [official documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md).
+You will learn how to migrate to Orbax through the following scenarios:
+
+* The most common use case: Saving/loading and managing checkpoints
+* A "lightweight" use case: "Pure" saving/loading without the top-level variable
+* Restoring checkpoints without a target pytree
+* Async checkpointing
+* Saving/loading a single JAX or NumPy Array
+
+To learn more about Orbax, check out the [quick start introductory Colab notebook](http://colab.research.google.com/github/google/orbax/blob/main/orbax//checkpoint/orbax_checkpoint.ipynb) and [the official Orbax documentation](https://github.com/google/orbax/blob/main/docs/checkpoint.md).
 
 
 ## Setup
 
+Install/upgrade [JAX](https://github.com/google/jax#installation), Flax and [Orbax](https://github.com/google/orbax). In addition, install [`nest_asyncio`](https://github.com/erdewit/nest_asyncio).
+
 ```python tags=["skip-execution"]
 !pip3 install -qq -U jaxlib jax flax orbax
 
-# This is required for Orbax only for notebook scenarios.
+# This is only required for Orbax in Colab/notebook scenarios.
 !pip3 install -qq nest_asyncio
 ```
 
@@ -40,34 +50,50 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from orbax import checkpoint as orbax_checkpoint
-# Orbax needs to enable asyncio in colab environment.
+# Orbax needs to have asyncio enabled in the Colab environment.
 import nest_asyncio
 nest_asyncio.apply()
 ```
 
 ```python
-# Some dummy variables to showcase
+# Create some dummy variables for this example.
 MAX_STEPS = 5
 CKPT_PYTREE = [12, {'foo': 'str', 'bar': np.array((2, 3))}, [1, 4, 10]]
 TARGET_PYTREE = [0, {'foo': '', 'bar': np.array((0))}, [0, 0, 0]]
 
 
-# Remove any existing checkpoints from the last notebook run.
+# For removing any existing checkpoints from the last notebook run:
 import shutil
 if os.path.exists('./tmp'):
     shutil.rmtree('./tmp')
 ```
 
-## Most Common Case: Save/Load + Management
+## Most common use case: Saving/loading and managing checkpoints
+
+This section covers the following scenario:
+
+*  Your original Flax `save_checkpoint()` or `save_checkpoint_multiprocess()` call contains the following arguments: `prefix`, `keep`, `keep_every_n_steps`; or
+*  You want to use some automatic management logic for your checkpoints (for example, for deleting old data, deleting data based on metrics/loss, and so on).
+
+In this case, you need to use `orbax.CheckpointManager`. This allows you to not only save and load your model, but also manage your checkpoints and delete outdated checkpoints *automatically*.
+
+To upgrade your code:
+
+1. Create and keep an `orbax.CheckpointManager` instance at the top level, customized with `orbax.CheckpointManagerOptions`.
+2. At runtime, call `orbax.CheckpointManager.save()` to save your data.
+3. Then, call `orbax.CheckpointManager.restore()` to restore your data.
+4. And, if your checkpoint includes some multi-host/multi-process array, pass the correct `mesh` into `flax.training.orbax_utils.restore_args_from_target()` to generate the correct `restore_args` before restoring.
+
+Below are code examples for before and after the migration to Orbax:
 
 ```python
 CKPT_DIR = './tmp/'
 
-# Before
+# Before: Using the Flax API
 
 # Inside a training loop
 for step in range(MAX_STEPS):
-   # ... do your training ...
+   # do your training
    checkpoints.save_checkpoint(CKPT_DIR, CKPT_PYTREE, step=step,
                                prefix='test_', keep=3, keep_every_n_steps=2)
 
@@ -78,9 +104,9 @@ checkpoints.restore_checkpoint(CKPT_DIR, target=TARGET_PYTREE, step=4, prefix='t
 ```python
 CKPT_DIR = './tmp/'
 
-# After
+# After: Using the Orbax API
 
-# At top level
+# At the top level
 mgr_options = orbax_checkpoint.CheckpointManagerOptions(
     max_to_keep=3, keep_period=2, step_prefix='test_')
 ckpt_mgr = orbax.checkpoint.CheckpointManager(
@@ -89,7 +115,7 @@ ckpt_mgr = orbax.checkpoint.CheckpointManager(
 
 # Inside a training loop
 for step in range(MAX_STEPS):
-   # ... do your training ...
+   # do your training
    save_args = orbax_utils.save_args_from_target(CKPT_PYTREE)
    ckpt_mgr.save(step, CKPT_PYTREE, save_kwargs={'save_args': save_args})
 
@@ -98,12 +124,18 @@ restore_args = orbax_utils.restore_args_from_target(TARGET_PYTREE, mesh=None)
 ckpt_mgr.restore(4, items=TARGET_PYTREE, restore_kwargs={'restore_args': restore_args})
 ```
 
-## Lightweight Case: Pure Save/Load without Top-level Variable
+## A "lightweight" case: "Pure" saving/loading without the top-level variable
+
+If you prefer to not maintain a top-level checkpoint manager, you can still save and restore any individual checkpoint with an `orbax.checkpoint.Checkpointer`. Note that this means you cannot use all the Orbax management features.
+
+To migrate to Orbax code, instead of using the `overwrite` argument in `flax.save_checkpoint()` use the `force` argument in `orbax.checkpoint.Checkpointer.save()`.
+
+For example:
 
 ```python
 PURE_CKPT_DIR = './tmp/pure'
 
-# Before
+# Before: Using the Flax API
 checkpoints.save_checkpoint(PURE_CKPT_DIR, CKPT_PYTREE, step=0, overwrite=True)
 checkpoints.restore_checkpoint(PURE_CKPT_DIR, target=TARGET_PYTREE)
 ```
@@ -111,20 +143,24 @@ checkpoints.restore_checkpoint(PURE_CKPT_DIR, target=TARGET_PYTREE)
 ```python
 PURE_CKPT_DIR_ORBAX = './tmp/pure/orbax'
 
-# After
-ckptr = orbax_checkpoint.Checkpointer(orbax_checkpoint.PyTreeCheckpointHandler())  # stateless object, can be created on-fly
+# After: Using the Orbax API
+ckptr = orbax_checkpoint.Checkpointer(orbax_checkpoint.PyTreeCheckpointHandler())  # A stateless object, can be created on the fly.
 ckptr.save(PURE_CKPT_DIR_ORBAX, CKPT_PYTREE,
            save_args=orbax_utils.save_args_from_target(CKPT_PYTREE), force=True)
 ckptr.restore(PURE_CKPT_DIR_ORBAX, item=TARGET_PYTREE,
               restore_args=orbax_utils.restore_args_from_target(TARGET_PYTREE, mesh=None))
 ```
 
-## Restore without a target pytree
+## Restoring checkpoints without a target pytree
+
+If you need to restore your checkpoints without a target pytree, pass `item=None` to `orbax.checkpoint.Checkpointer` or pass `items=None` to `orbax.CheckpointManager`'s `.restore()` method, which should trigger the restoration.
+
+For example:
 
 ```python
 NOTARGET_CKPT_DIR = './tmp/no_target'
 
-# Before
+# Before: Using the Flax API
 checkpoints.save_checkpoint(NOTARGET_CKPT_DIR, CKPT_PYTREE, step=0)
 checkpoints.restore_checkpoint(NOTARGET_CKPT_DIR, target=None)
 ```
@@ -132,19 +168,31 @@ checkpoints.restore_checkpoint(NOTARGET_CKPT_DIR, target=None)
 ```python
 NOTARGET_CKPT_DIR = './tmp/no_target/orbax'
 
-# After
+# After: Using the Orbax API
 ckptr = orbax_checkpoint.Checkpointer(orbax_checkpoint.PyTreeCheckpointHandler())
 ckptr.save(NOTARGET_CKPT_DIR, CKPT_PYTREE,
            save_args=orbax_utils.save_args_from_target(CKPT_PYTREE))
 ckptr.restore(NOTARGET_CKPT_DIR, item=None)
 ```
 
-## Save/Load a single JAX or Numpy Array
+## Async checkpointing
+
+To make your checkpoint-saving asynchronous, substitute `orbax.checkpoint.Checkpointer` with `orbax.checkpoint.AsyncCheckpointer`.
+
+Then, you can call `orbax.checkpoint.AsyncCheckpointer.wait_until_finished()` or Orbax's `CheckpointerManager.wait_until_finished()` to wait for the save the complete.
+
+For more details, read the [checkpoint guide](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html#asynchronized-checkpointing).
+
+## Saving/loading a single JAX or NumPy Array
+
+The `orbax.checkpoint.PyTreeCheckpointHandler` class, as the name suggests, can only be used for pytrees. Therefore, if you need to save/restore a single pytree leaf (for example, an array), use `orbax.checkpoint.ArrayCheckpointHandler` instead.
+
+For example:
 
 ```python
 ARR_CKPT_DIR = './tmp/singleton'
 
-# Before
+# Before: Using the Flax API
 checkpoints.save_checkpoint(ARR_CKPT_DIR, jnp.arange(10), step=0)
 checkpoints.restore_checkpoint(ARR_CKPT_DIR, target=None)
 ```
@@ -152,7 +200,7 @@ checkpoints.restore_checkpoint(ARR_CKPT_DIR, target=None)
 ```python
 ARR_CKPT_DIR = './tmp/singleton/orbax'
 
-# After
+# After: Using the Orbax API
 ckptr = orbax.checkpoint.Checkpointer(orbax.checkpoint.ArrayCheckpointHandler())  # stateless object, can be created on-fly
 ckptr.save(ARR_CKPT_DIR, jnp.arange(10))
 ckptr.restore(ARR_CKPT_DIR, item=None)


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/19637339/222004469-cbdc7472-34ff-4e77-ba64-911d2348b56a.png)

![image](https://user-images.githubusercontent.com/19637339/222004560-1fe83bf3-7a09-4f1a-9e44-f24a59ae04f8.png)

![image](https://user-images.githubusercontent.com/19637339/222004681-9f65b2f4-b29a-4227-90a2-d77f2d07c707.png)

Added minor improvements.

- Linted, rephrased, reorganized (as discussed)
- Now with a ToC! (as discussed)
- Fixed the Colab link
- The notebook's text mirrors the RST file's text  
  - This also ensures the Async checkpointing section is not missed by some users